### PR TITLE
Added Feature: Set-MoodleCohort uses passed [MoodleCohort] for defaults

### DIFF
--- a/Moodle/public/Set-MoodleCohort.ps1
+++ b/Moodle/public/Set-MoodleCohort.ps1
@@ -42,6 +42,7 @@ Updates cohort #1's name and description.
 #>
 function Set-MoodleCohort {
     [CmdletBinding(SupportsShouldProcess)]
+    [CmdletBinding(DefaultParameterSetName='id-system')]
     param (
         [Parameter(Mandatory,ParameterSetName='id-system',ValueFromPipelineByPropertyName)]
         [Parameter(Mandatory,ParameterSetName='id-catid',ValueFromPipelineByPropertyName)]
@@ -65,10 +66,10 @@ function Set-MoodleCohort {
         [Parameter(Mandatory,ParameterSetName='cohort-category',ValueFromPipelineByPropertyName)]
         [MoodleCourseCategory] $Category,
 
-        [Parameter(Mandatory,ValueFromPipelineByPropertyName)]
+        [Parameter(ValueFromPipelineByPropertyName)]
         [string] $Name,
 
-        [Parameter(Mandatory,ValueFromPipelineByPropertyName)]
+        [Parameter(ValueFromPipelineByPropertyName)]
         [string] $IdNumber,
 
         [Parameter(ValueFromPipelineByPropertyName)]

--- a/Moodle/public/Set-MoodleCohort.ps1
+++ b/Moodle/public/Set-MoodleCohort.ps1
@@ -42,7 +42,7 @@ Updates cohort #1's name and description.
 #>
 function Set-MoodleCohort {
     [CmdletBinding(SupportsShouldProcess)]
-    [CmdletBinding(DefaultParameterSetName='id-system')]
+
     param (
         [Parameter(Mandatory,ParameterSetName='id-system',ValueFromPipelineByPropertyName)]
         [Parameter(Mandatory,ParameterSetName='id-catid',ValueFromPipelineByPropertyName)]
@@ -65,11 +65,21 @@ function Set-MoodleCohort {
         [Parameter(Mandatory,ParameterSetName='id-category',ValueFromPipelineByPropertyName)]
         [Parameter(Mandatory,ParameterSetName='cohort-category',ValueFromPipelineByPropertyName)]
         [MoodleCourseCategory] $Category,
-
-        [Parameter(ValueFromPipelineByPropertyName)]
+        
+        [Parameter(Mandatory,ParameterSetName='id-system',ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory,ParameterSetName='id-catid',ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory,ParameterSetName='id-category',ValueFromPipelineByPropertyName)]
+        [Parameter(ParameterSetName='cohort-system',ValueFromPipelineByPropertyName)]
+        [Parameter(ParameterSetName='cohort-category',ValueFromPipelineByPropertyName)]
+        [Parameter(ParameterSetName='cohort-catid',ValueFromPipelineByPropertyName)]
         [string] $Name,
 
-        [Parameter(ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory,ParameterSetName='id-system',ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory,ParameterSetName='id-catid',ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory,ParameterSetName='id-category',ValueFromPipelineByPropertyName)]
+        [Parameter(ParameterSetName='cohort-system',ValueFromPipelineByPropertyName)]
+        [Parameter(ParameterSetName='cohort-category',ValueFromPipelineByPropertyName)]
+        [Parameter(ParameterSetName='cohort-catid',ValueFromPipelineByPropertyName)]
         [string] $IdNumber,
 
         [Parameter(ValueFromPipelineByPropertyName)]
@@ -118,6 +128,18 @@ function Set-MoodleCohort {
         foreach ($key in $params.Keys) {
             if ($PSBoundParameters.ContainsKey($key)) {
                 $body["cohorts[0][$key]"] = $params[$key]
+            } elseif ($PSBoundParameters.ContainsKey('Cohort')){
+                Switch ($key){
+                    'descriptionformat' {
+                        $body["cohorts[0][$key]"] = [int]$Cohort.$key
+                    }
+                    'visible' {
+                        $body["cohorts[0][$key]"] = if ($Cohort.$key) { 1 } else { 0 }
+                    }
+                    'default' {
+                        $body["cohorts[0][$key]"] = $Cohort.$key
+                    }    
+                }
             }
         }
 


### PR DESCRIPTION
 Set-MoodleCohort now  use passed [MoodleCohort] for value defaults. 

This makes pipiping more lean, as no need to mandatory  pass name or idnumber any more.
for example:

```
#update description
Get-MoodleCohort -id [someid] | Set-MoodleCohort -System -Description "Updated at $(get-date)"

# or update just idnumber
Get-MoodleCohort -id [someid]| Set-MoodleCohort -System -IdNumber "Someid"

#or just update [MoodleCohort]  and pass it to Set-MoodleCohort
$cohort = Get-MoodleCohort -id [ someid]
$cohort.idnumber = "SomeNewId"
$cohort | Set-MoodleCohort -System


```
 